### PR TITLE
fix call to make_tested_resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ cache:
   directories: "~/.R"
 before_script:
   - mkdir -p "$R_LIBS_USER"
-  - Rscript -e 'install.packages("devtools")'
-  - Rscript -e 'install.packages("memoise")'
+  - Rscript --vanilla -e 'install.packages("devtools")'
 script: Rscript -e 'library(syberia); library(methods); devtools::with_options(list(stub
   = 1), force); tryCatch({ syberia::test_engine(); quit(status = 0) }, error = function(e) { message(e); quit(status = 1); })'
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 before_script:
   - mkdir -p "$R_LIBS_USER"
   - Rscript -e 'install.packages("devtools")'
+  - Rscript -e 'install.packages("memoise")'
 script: Rscript -e 'library(syberia); library(methods); devtools::with_options(list(stub
   = 1), force); tryCatch({ syberia::test_engine(); quit(status = 0) }, error = function(e) { message(e); quit(status = 1); })'
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ cache:
   directories: "~/.R"
 before_script:
   - mkdir -p "$R_LIBS_USER"
-  - Rscirpt --vanilla -e 'if (length(find.package("devtools", quiet = TRUE)) == 0L) { install.packages("devtools", repos = "http://cran.rstudio.com"); devtools::install_github("hadley/devtools") }'
-  - Rscirpt --vanilla -e 'if (length(find.package("memoise", quiet = TRUE)) == 0L) { install.packages("memoise", repos = "http://cran.rstudio.com") }'
+  - Rscript --vanilla -e 'if (length(find.package("devtools", quiet = TRUE)) == 0L) { install.packages("devtools", repos = "http://cran.rstudio.com"); devtools::install_github("hadley/devtools") }'
+  - Rscript --vanilla -e 'if (length(find.package("memoise", quiet = TRUE)) == 0L) { install.packages("memoise", repos = "http://cran.rstudio.com") }'
 script: Rscript -e 'library(syberia); library(methods); devtools::with_options(list(stub
   = 1), force); tryCatch({ syberia::test_engine(); quit(status = 0) }, error = function(e) { message(e); quit(status = 1); })'
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ cache:
   directories: "~/.R"
 before_script:
   - mkdir -p "$R_LIBS_USER"
-  - Rscript --vanilla -e 'install.packages("devtools")'
+  - Rscirpt --vanilla -e 'if (length(find.package("devtools", quiet = TRUE)) == 0L) { install.packages("devtools", repos = "http://cran.rstudio.com"); devtools::install_github("hadley/devtools") }'
+  - Rscirpt --vanilla -e 'if (length(find.package("memoise", quiet = TRUE)) == 0L) { install.packages("memoise", repos = "http://cran.rstudio.com") }'
 script: Rscript -e 'library(syberia); library(methods); devtools::with_options(list(stub
   = 1), force); tryCatch({ syberia::test_engine(); quit(status = 0) }, error = function(e) { message(e); quit(status = 1); })'
 notifications:

--- a/lib/controllers/test/plain.R
+++ b/lib/controllers/test/plain.R
@@ -11,16 +11,15 @@ preprocessor <- function(resource, director, source_env, source, filename, args)
 
   make_tested_resource <- function(...) {
     if (is(director, "syberia_engine")) {
-      director$resource(tested_resource, ..., children. = FALSE, parent. = FALSE)
+      director$resource(..., children. = FALSE, parent. = FALSE)
     } else {
-      director$resource(tested_resource, ...)
+      director$resource(...)
     }
   }
 
-  force(resource)
   source_env$resource <- function(name, ...) {
     if (missing(name)) {
-      make_tested_resource(resource, ...)
+      make_tested_resource(tested_resource, ...)
     } else {
       make_tested_resource(...)
     }


### PR DESCRIPTION
Found a bug when running tests in an engine, where the test file called out to resources other than the tested resource.