### PR TITLE
recompile resources in tests controller

### DIFF
--- a/lib/controllers/test/plain.R
+++ b/lib/controllers/test/plain.R
@@ -19,9 +19,9 @@ preprocessor <- function(resource, director, source_env, source, filename, args)
 
   source_env$resource <- function(name, ...) {
     if (missing(name)) {
-      make_tested_resource(tested_resource, ...)
+      make_tested_resource(tested_resource, ..., recompile. = TRUE)
     } else {
-      make_tested_resource(...)
+      make_tested_resource(..., recompile. = TRUE)
     }
   }
 


### PR DESCRIPTION
Ran into a problem where a resource was preserving state from one unit test to another. Turns out the resource was not being recompiled between calls to `resource()`.